### PR TITLE
Include missing spdlog library

### DIFF
--- a/API/include/dogbot/DogBotAPI.hh
+++ b/API/include/dogbot/DogBotAPI.hh
@@ -3,6 +3,7 @@
 
 #include "dogbot/Servo.hh"
 #include <jsoncpp/json/json.h>
+#include <spdlog/sinks/stdout_sinks.h>
 #include "dogbot/Coms.hh"
 #include "dogbot/LegKinematics.hh"
 #include "dogbot/CallbackArray.hh"


### PR DESCRIPTION
A missing include was added to fix installation in Ubuntu Focal.